### PR TITLE
Added support of custom author names

### DIFF
--- a/scaffolds/draft.md
+++ b/scaffolds/draft.md
@@ -1,3 +1,4 @@
 title: {{ title }}
+author:
 tags:
 ---

--- a/scaffolds/post.md
+++ b/scaffolds/post.md
@@ -1,4 +1,5 @@
 title: {{ title }}
 date: {{ date }}
+author:
 tags:
 ---

--- a/themes/apollo/layout/_partial/article.ejs
+++ b/themes/apollo/layout/_partial/article.ejs
@@ -3,7 +3,7 @@
 		<span class="meta-elements date">
 			<%- partial('post/date', {class_name: 'article-date', date_format: null}) %>
 		</span>
-		<span class="meta-elements author"><%= config.author %></span>
+		<span class="meta-elements author"><%= post.author ? post.author : config.author %></span>
 		<div class="commentscount">
 			<% if (post.comments && config.disqus_shortname){ %>
 				<a href="<%- post.permalink %>#disqus_thread" class="article-comment-link">Comments</a>


### PR DESCRIPTION
But you can't query for all post published by an author, that would require modification of hexo. Something like WordPress does that out of the box.

If a post has `author:` specified, the author name from the post is used. Otherwise the author name from the config file is used.
